### PR TITLE
Heroku config v3

### DIFF
--- a/qs_django/settings.py
+++ b/qs_django/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['fierce-mountain-30405.herokuapp.com', 'localhost']
 
 
 # Application definition

--- a/qs_django/settings.py
+++ b/qs_django/settings.py
@@ -125,5 +125,3 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
-
-django_heroku.settings(locals())


### PR DESCRIPTION
For now, the django_heroku.settings(locals()) line is not needed and caused a build to fail. May revisit later. 